### PR TITLE
Initialize Expo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.expo
+.expo-shared
+npm-debug.log
+.DS_Store

--- a/App.js
+++ b/App.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import StackNavigator from './navigation/StackNavigator';
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <StackNavigator />
+    </NavigationContainer>
+  );
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "proa-app",
+    "slug": "proa-app",
+    "version": "1.0.0",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/firebase/firebaseConfig.js
+++ b/firebase/firebaseConfig.js
@@ -1,0 +1,3 @@
+export default {
+  // Configuración de Firebase pendiente
+};

--- a/navigation/StackNavigator.js
+++ b/navigation/StackNavigator.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/LoginScreen';
+import MenuScreen from '../screens/MenuScreen';
+import FormScreen from '../screens/FormScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function StackNavigator() {
+  return (
+    <Stack.Navigator initialRouteName="Login">
+      <Stack.Screen name="Login" component={LoginScreen} />
+      <Stack.Screen name="Menu" component={MenuScreen} />
+      <Stack.Screen name="Form" component={FormScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "proa-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "firebase": "^9.23.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/screens/FormScreen.js
+++ b/screens/FormScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function FormScreen({ route }) {
+  const { modo } = route.params || {};
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Modo: {modo}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 24,
+  },
+});

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    // Por implementar
+    navigation.navigate('Menu');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Correo"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+        autoCapitalize="none"
+      />
+      <TextInput
+        placeholder="Contraseña"
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+        secureTextEntry
+      />
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/screens/MenuScreen.js
+++ b/screens/MenuScreen.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+
+export default function MenuScreen({ navigation }) {
+  const goToForm = (modo) => {
+    navigation.navigate('Form', { modo });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Nuevo" onPress={() => goToForm('Nuevo')} />
+      <Button title="Modificar" onPress={() => goToForm('Modificar')} />
+      <Button title="Eliminar" onPress={() => goToForm('Eliminar')} />
+      <Button title="Consultar" onPress={() => goToForm('Consultar')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+    padding: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold an Expo project manually since `npx create-expo-app .` failed
- add React Navigation stack and basic screens
- create placeholders for Firebase config

## Testing
- `npx create-expo-app .` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c4e938f5883249201a2908f3f5d29