### PR TITLE
Add greeting and improve login UX

### DIFF
--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,23 +1,23 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, Text, Alert } from 'react-native';
+import { View, TextInput, Button, Text } from 'react-native';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '../firebase/firebaseConfig';
 
 export default function LoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState(null);
+  const [error, setError] = useState('');
 
   const handleLogin = async () => {
     try {
       const userCredential = await signInWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
       console.log('Login exitoso:', user.email);
+      setError('');
       navigation.replace('Menu');
     } catch (err) {
       console.log('Error al iniciar sesión:', err.message);
-      setError(err.message);
-      Alert.alert('Error de inicio de sesión', err.message);
+      setError('Correo electrónico o contraseña incorrectos');
     }
   };
 
@@ -36,6 +36,8 @@ export default function LoginScreen({ navigation }) {
         value={password}
         onChangeText={setPassword}
         secureTextEntry
+        returnKeyType="done"
+        onSubmitEditing={handleLogin}
         style={{ marginBottom: 20, borderWidth: 1, padding: 10, borderRadius: 5 }}
       />
       <Button title="Ingresar" onPress={handleLogin} />

--- a/screens/MenuScreen.js
+++ b/screens/MenuScreen.js
@@ -1,13 +1,16 @@
 import React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { View, Button, StyleSheet, Text } from 'react-native';
+import { auth } from '../firebase/firebaseConfig';
 
 export default function MenuScreen({ navigation }) {
+  const email = auth.currentUser?.email;
   const goToForm = (modo) => {
     navigation.navigate('Form', { modo });
   };
 
   return (
     <View style={styles.container}>
+      <Text style={styles.greeting}>¡Hola, {email}!</Text>
       <Button title="Nuevo" onPress={() => goToForm('Nuevo')} />
       <Button title="Modificar" onPress={() => goToForm('Modificar')} />
       <Button title="Eliminar" onPress={() => goToForm('Eliminar')} />
@@ -19,7 +22,12 @@ export default function MenuScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'space-around',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
     padding: 16,
+  },
+  greeting: {
+    fontSize: 18,
+    marginBottom: 20,
   },
 });


### PR DESCRIPTION
## Summary
- remove Alert usage in login and show inline error instead
- trigger login on submit of password field
- display current user's email in MenuScreen

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686c713785588324abc39f0b22877da5